### PR TITLE
ChannelクラスclilentList_, operatorList_のデータ型を変更

### DIFF
--- a/hnoguchi/ft_irc/includes/Channel.hpp
+++ b/hnoguchi/ft_irc/includes/Channel.hpp
@@ -25,40 +25,38 @@ enum ClientMode
 
 class Channel
 {
-	private:
-		std::string	name_;
-		// std::string	prefix_;
-		std::string	topic_;
-		int			mode_;
-		// std::vector<Client *> clientList_;
-		// std::vector<Client *> operatorList_;
-		std::vector<Client *> clientList_;
-		std::vector<Client *> operatorList_;
+private:
+	std::string						name_;
+	// std::string					prefix_;
+	std::string						topic_;
+	int								mode_;
+	std::map<std::string, Client *>	clientList_;
+	std::map<std::string, Client *>	operatorList_;
 
-	public:
-		// CONSTRUCTER
-		Channel(const std::string& name);
-		Channel(const Channel& src);
-		Channel&	operator=(const Channel& rhs);
+public:
+	// CONSTRUCTER
+	Channel(const std::string& name);
+	Channel(const Channel& src);
+	Channel&	operator=(const Channel& rhs);
 
-		// DESTRUCTER
-		~Channel();
+	// DESTRUCTER
+	~Channel();
 
-		// Setters
-		void	setName(std::string& name);
-		void	setTopic(std::string& topic);
-		// void	setPrefix(std::string &name);
-		void	setChannelMode(ChannelMode mode);
-		void	addListClient(Client& client);
-		void	addListOperator(Client& ope);
+	// Setters
+	void	setName(std::string& name);
+	void	setTopic(std::string& topic);
+	// void	setPrefix(std::string &name);
+	void	setMode(ChannelMode mode);
+	void	addListClient(Client& client);
+	void	addListOperator(Client& ope);
 
-		// Getter
-		const std::string&				getName() const;
-		const std::string&				getTopic() const;
-		// const std::string&			getPrefix() const;
-		const ChannelMode&				getChannelMode() const;
-		const std::vector<Client *>&	getClientList() const;
-		const std::vector<Client *>&	getOperatorList() const;
+	// Getter
+	const std::string&						getName() const;
+	const std::string&						getTopic() const;
+	// const std::string&					getPrefix() const;
+	const int&								getMode() const;
+	const std::map<std::string, Client *>&	getClientList() const;
+	const std::map<std::string, Client *>&	getOperatorList() const;
 };
 
 #endif

--- a/hnoguchi/interface/Channel.hpp
+++ b/hnoguchi/interface/Channel.hpp
@@ -3,6 +3,9 @@
 
 #include <iostream>
 #include <vector>
+#include "Client.hpp"
+
+class Client;
 
 enum ChannelMode
 {
@@ -17,28 +20,43 @@ enum ChannelMode
 enum ClientMode
 {
 	REGULAR_USERS,	// regular users
-	OPERATOR		// operator
+	OPERATOR_USERS		// operator
 };
 
 class Channel
 {
-	private:
-		std::string	name_;
-		ChannelMode	mode_;
-	public:
-		std::vector<int *> normal_clients_;
-		std::vector<int *> operator_clients_;
+private:
+	std::string				name_;
+	// std::string			prefix_;
+	std::string				topic_;
+	int						mode_;
+	std::vector<Client *>	clientList_;
+	std::vector<Client *>	operatorList_;
 
-		// CONSTRUCTER
-		Channel(std::string &name);
+public:
+	// CONSTRUCTER
+	Channel(const std::string& name);
+	Channel(const Channel& src);
+	Channel&	operator=(const Channel& rhs);
 
-		// Setters
-		void	setName(std::string &name);
-		void	setChannelMode(ChannelMode mode);
+	// DESTRUCTER
+	~Channel();
 
-		// Getter
-		std::string &getName(void) const;
-		ChannelMode &getChannelMode(void) const;
-}
+	// Setters
+	void	setName(std::string& name);
+	void	setTopic(std::string& topic);
+	// void	setPrefix(std::string &name);
+	void	setMode(ChannelMode mode);
+	void	addListClient(Client& client);
+	void	addListOperator(Client& ope);
+
+	// Getter
+	const std::string&				getName() const;
+	const std::string&				getTopic() const;
+	// const std::string&			getPrefix() const;
+	const int&						getMode() const;
+	const std::vector<Client *>&	getClientList() const;
+	const std::vector<Client *>&	getOperatorList() const;
+};
 
 #endif


### PR DESCRIPTION
std::map<std::string, Client *>からstd::vector<Client *>に変更。
初めは、mapのキーにnicknameを使用して検索性を上げようと思ったが、mapの特徴（キーの変更は、原則行わない。）とnicknameの特徴（変更される可能性がある。）に齟齬が生じるため、vectorにした。