### PR TITLE
禁止関数の確認及びincludeの整理

### DIFF
--- a/hnoguchi/ft_irc/channel/Channel.cpp
+++ b/hnoguchi/ft_irc/channel/Channel.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include "./Channel.hpp"
 #include "../color.hpp"
 #include "../user/User.hpp"
@@ -175,6 +174,7 @@ bool	Channel::isOperator(User* user) const {
 	return (true);
 }
 
+#include <iostream>
 void	Channel::debugPrintChannel() const {
 	std::cout << CYAN << "[CHANNEL INFO] -----------------" << END << std::endl;
 	std::cout << "[name]      | [" << this->getName() << "]" << std::endl;

--- a/hnoguchi/ft_irc/channel/Channel.hpp
+++ b/hnoguchi/ft_irc/channel/Channel.hpp
@@ -1,10 +1,11 @@
 #ifndef CHANNEL_HPP
 # define CHANNEL_HPP
 
-#include <iostream>
-#include <string>
-#include <vector>
-#include "../user/User.hpp"
+# include <string>
+# include <vector>
+# include <algorithm>
+# include <stdexcept>
+# include "../user/User.hpp"
 
 enum kChannelMode {
 	kInviteOnly = (1 << 0),

--- a/hnoguchi/ft_irc/debug/debug.hpp
+++ b/hnoguchi/ft_irc/debug/debug.hpp
@@ -1,10 +1,11 @@
 #ifndef DEBUG_HPP
 # define DEBUG_HPP
 
-#include <iostream>
-#include <string>
+# include <iostream>
+# include <string>
+# include <cerrno>
+# include <cstdio>
 
 void	debugPrintErrorMessage(const std::string &message);
 
 #endif  // DEBUG_HPP
-

--- a/hnoguchi/ft_irc/execute/Execute.hpp
+++ b/hnoguchi/ft_irc/execute/Execute.hpp
@@ -1,9 +1,10 @@
 #ifndef EXECUTE_HPP
 # define EXECUTE_HPP
 
-#include <iostream>
+// #include <iostream>
 #include <string>
-#include <vector>
+// #include <vector>
+#include <stdexcept>
 #include "../server/Info.hpp"
 #include "../parser/Parser.hpp"
 #include "../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/channel_operations/cmdChannelMode.cpp
+++ b/hnoguchi/ft_irc/execute/channel_operations/cmdChannelMode.cpp
@@ -46,8 +46,11 @@
  *    t - チャネル運営者のみが設定可能なトピックフラグ設定の切り替え
  */
 
+#include <string>
 #include <vector>
 #include <cstdlib>
+#include <sstream>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/channel_operations/cmdInvite.cpp
+++ b/hnoguchi/ft_irc/execute/channel_operations/cmdInvite.cpp
@@ -16,7 +16,9 @@
  *    INVITE Wiz #Twilight_Zone       ; Command to invite WiZ to #Twilight_zone
  */
 
+#include <string>
 #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/channel_operations/cmdJoin.cpp
+++ b/hnoguchi/ft_irc/execute/channel_operations/cmdJoin.cpp
@@ -26,8 +26,10 @@
  *                                ; JOIN message from WiZ on channel #Twilight_zone
  */
 
-#include <iostream>
+#include <string>
+// #include <iostream>
 #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/channel_operations/cmdKick.cpp
+++ b/hnoguchi/ft_irc/execute/channel_operations/cmdKick.cpp
@@ -18,7 +18,9 @@
  *
  */
 
+#include <string>
 #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/channel_operations/cmdPart.cpp
+++ b/hnoguchi/ft_irc/execute/channel_operations/cmdPart.cpp
@@ -14,7 +14,9 @@
  *                                    ; User WiZ leaving channel "#playzone" with the message "I lost".
  */
 
+#include <string>
 #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/channel_operations/cmdTopic.cpp
+++ b/hnoguchi/ft_irc/execute/channel_operations/cmdTopic.cpp
@@ -19,7 +19,9 @@
  *    TOPIC #test                     ; Command to check the topic for #test.
  */
 
+#include <string>
 #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/connection_registration/cmdNick.cpp
+++ b/hnoguchi/ft_irc/execute/connection_registration/cmdNick.cpp
@@ -15,7 +15,9 @@
  *                    ; Server telling that WiZ changed his nickname to Kilroy.
  */
 
-#include <vector>
+#include <string>
+// #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../user/User.hpp"
 #include "../../debug/debug.hpp"

--- a/hnoguchi/ft_irc/execute/connection_registration/cmdOper.cpp
+++ b/hnoguchi/ft_irc/execute/connection_registration/cmdOper.cpp
@@ -12,7 +12,9 @@
  *             ; Attempt to register as an operator using a username of "foo" and "bar" as the password.
  */
 
-#include <vector>
+#include <string>
+// #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/connection_registration/cmdPass.cpp
+++ b/hnoguchi/ft_irc/execute/connection_registration/cmdPass.cpp
@@ -9,7 +9,9 @@
  * example   :　PASS secretpasswordhere
  */
 
-#include <vector>
+#include <string>
+// #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../user/User.hpp"
 #include "../../debug/debug.hpp"

--- a/hnoguchi/ft_irc/execute/connection_registration/cmdQuit.cpp
+++ b/hnoguchi/ft_irc/execute/connection_registration/cmdQuit.cpp
@@ -13,7 +13,9 @@
  *             ; User syrk has quit IRC to have lunch.
  */
 
+#include <string>
 #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/connection_registration/cmdUser.cpp
+++ b/hnoguchi/ft_irc/execute/connection_registration/cmdUser.cpp
@@ -15,7 +15,9 @@
  *             ; User registering themselves with a username of "guest" and real name "Ronnie Reagan", and asking to be set invisible.
  */
 
-#include <vector>
+#include <string>
+// #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../user/User.hpp"
 #include "../../parser/Parser.hpp"

--- a/hnoguchi/ft_irc/execute/connection_registration/cmdUserMode.cpp
+++ b/hnoguchi/ft_irc/execute/connection_registration/cmdUserMode.cpp
@@ -19,7 +19,9 @@
  *             ; WiZ 'deopping' (removing operator status).
  */
 
-#include <vector>
+#include <string>
+// #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/execute/miscellaneous/cmdPong.cpp
+++ b/hnoguchi/ft_irc/execute/miscellaneous/cmdPong.cpp
@@ -11,7 +11,9 @@
  *
  */
 
-#include <iostream>
+#include <string>
+// #include <iostream>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../user/User.hpp"
 #include "../../server/Info.hpp"

--- a/hnoguchi/ft_irc/execute/sending/cmdNotice.cpp
+++ b/hnoguchi/ft_irc/execute/sending/cmdNotice.cpp
@@ -13,7 +13,10 @@
  *             [ 301 RPL_AWAY             "<nick> :<away message>"
  */
 
-#include <iostream>
+#include <string>
+#include <vector>
+// #include <iostream>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../user/User.hpp"
 #include "../../server/Info.hpp"

--- a/hnoguchi/ft_irc/execute/sending/cmdPrivmsg.cpp
+++ b/hnoguchi/ft_irc/execute/sending/cmdPrivmsg.cpp
@@ -38,8 +38,10 @@
  *    「ホスト名が[*.edu]と一致するホストから来たすべてのユーザへのメッセージ」
  */
 
-#include <iostream>
+#include <string>
+// #include <iostream>
 #include <vector>
+#include <stdexcept>
 #include "../Execute.hpp"
 #include "../../debug/debug.hpp"
 #include "../../user/User.hpp"

--- a/hnoguchi/ft_irc/main.cpp
+++ b/hnoguchi/ft_irc/main.cpp
@@ -1,4 +1,10 @@
 #include <signal.h>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <cstdio>
+#include <algorithm>
+#include <stdexcept>
 #include "./color.hpp"
 #include "./server/Server.hpp"
 

--- a/hnoguchi/ft_irc/parser/IsChar.cpp
+++ b/hnoguchi/ft_irc/parser/IsChar.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "./IsChar.hpp"
 #include "../color.hpp"
 
@@ -57,6 +56,7 @@ bool	IsChar::isFuncString(const std::string &str, bool (*func)(const char)) {
 }
 
 #ifdef UTEST_ISCHAR
+# include <iostream>
 void	test(IsChar* obj, bool (IsChar::*func)(const char)) {
 	std::cout.unsetf(std::ios::showbase);
 	std::cout.setf(std::ios::uppercase);

--- a/hnoguchi/ft_irc/parser/IsChar.hpp
+++ b/hnoguchi/ft_irc/parser/IsChar.hpp
@@ -2,6 +2,8 @@
 # define ISCHAR_HPP
 
 # include <string>
+# include <algorithm>
+# include <stdexcept>
 
 class IsChar {
  public:

--- a/hnoguchi/ft_irc/parser/Param.cpp
+++ b/hnoguchi/ft_irc/parser/Param.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "./Param.hpp"
 #include "./Token.hpp"
 
@@ -32,6 +31,7 @@ const std::string&	Param::getValue() const {
 }
 
 // debug
+#include <iostream>
 void	Param::printParam() const {
 	std::cout << "tType   : " << this->tType_ << " | " << std::flush;
 	std::cout << "pType   : " << this->pType_ << " | " << std::flush;

--- a/hnoguchi/ft_irc/parser/ParsedMsg.cpp
+++ b/hnoguchi/ft_irc/parser/ParsedMsg.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "./ParsedMsg.hpp"
 #include "./Param.hpp"
 

--- a/hnoguchi/ft_irc/parser/ParsedMsg.hpp
+++ b/hnoguchi/ft_irc/parser/ParsedMsg.hpp
@@ -3,6 +3,8 @@
 
 #include <string>
 #include <vector>
+#include <iostream>
+#include <stdexcept>
 #include "./Token.hpp"
 #include "./Param.hpp"
 

--- a/hnoguchi/ft_irc/parser/Parser.cpp
+++ b/hnoguchi/ft_irc/parser/Parser.cpp
@@ -59,7 +59,7 @@ void	Parser::tokenize(std::string *message, std::vector<Token> *tokens) {
 		command.setType(kCmdString);
 		command.setValue(word);
 		tokens->push_back(command);
-		while(startPos < message->size()) {
+		while (startPos < message->size()) {
 			Token	param;
 			delimPos = message->find(' ', startPos);
 			if (delimPos == message->npos && startPos < message->size()) {
@@ -624,6 +624,7 @@ const ParsedMsg&	Parser::getParsedMsg() const {
 }
 
 // DEBUG
+#include <iostream>
 void	Parser::printTokens(const std::vector<Token>& tokens) {
 	// std::cout << YELLOW << "[Tokens]    ____________________" << END << std::endl;
 	// std::cout << "[Type] : [Value]" << std::endl;

--- a/hnoguchi/ft_irc/parser/Parser.hpp
+++ b/hnoguchi/ft_irc/parser/Parser.hpp
@@ -1,12 +1,11 @@
 #ifndef PARSER_HPP
 # define PARSER_HPP
 
-#include <iostream>
+#include <string>
+#include <vector>
 #include <locale>
 #include <sstream>
 #include <stdexcept>
-#include <string>
-#include <vector>
 #include "./Token.hpp"
 #include "./Param.hpp"
 #include "./ParsedMsg.hpp"

--- a/hnoguchi/ft_irc/parser/Token.cpp
+++ b/hnoguchi/ft_irc/parser/Token.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "./Token.hpp"
 
 // CONSTRUCTOR & DESTRUCTOR
@@ -39,6 +38,7 @@ const std::string&	Token::getValue() const {
 }
 
 // debug
+#include <iostream>
 void	Token::printToken() const {
 	std::cout << "Type   : " << this->type_ << " | " << std::flush;
 	std::cout << "Value  : [" << this->value_ << "]" << std::endl;

--- a/hnoguchi/ft_irc/parser/ValidParam.cpp
+++ b/hnoguchi/ft_irc/parser/ValidParam.cpp
@@ -1,6 +1,3 @@
-#include <iostream>
-#include <iomanip>
-#include <sstream>
 #include "./ValidParam.hpp"
 #include "./IsChar.hpp"
 #include "../color.hpp"

--- a/hnoguchi/ft_irc/parser/ValidParam.hpp
+++ b/hnoguchi/ft_irc/parser/ValidParam.hpp
@@ -2,6 +2,9 @@
 # define VALIDPARAM_HPP
 
 # include <string>
+# include <iostream>
+# include <iomanip>
+# include <sstream>
 # include "./IsChar.hpp"
 
 class ValidParam : private IsChar {

--- a/hnoguchi/ft_irc/reply/Reply.hpp
+++ b/hnoguchi/ft_irc/reply/Reply.hpp
@@ -2,7 +2,10 @@
 # define REPLY_HPP
 
 #include <string>
+#include <sstream>
+#include <vector>
 #include <ctime>
+#include <stdexcept>
 #include "../user/User.hpp"
 #include "../server/Info.hpp"
 #include "../parser/Parser.hpp"

--- a/hnoguchi/ft_irc/server/Config.cpp
+++ b/hnoguchi/ft_irc/server/Config.cpp
@@ -1,4 +1,3 @@
-# include <iostream>
 # include "./Config.hpp"
 # include "../color.hpp"
 
@@ -102,6 +101,7 @@ const std::string*	Config::getCommandList() const {
 // 	this->connectPwd_ = pwd;
 // }
 
+# include <iostream>
 void	Config::debugPrintConfig() const {
 	std::cout << "[CONFIG INFO] ------------------" << std::endl;
 	std::cout << "[maxClient]    : [" << this->maxClient_ << "]" << std::endl;

--- a/hnoguchi/ft_irc/server/Info.cpp
+++ b/hnoguchi/ft_irc/server/Info.cpp
@@ -1,5 +1,3 @@
-#include <vector>
-#include <stdexcept>
 #include "./Info.hpp"
 #include "./Config.hpp"
 #include "../debug/debug.hpp"

--- a/hnoguchi/ft_irc/server/Info.hpp
+++ b/hnoguchi/ft_irc/server/Info.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <stdexcept>
 #include "./Config.hpp"
 #include "../user/User.hpp"
 #include "../channel/Channel.hpp"

--- a/hnoguchi/ft_irc/server/Server.hpp
+++ b/hnoguchi/ft_irc/server/Server.hpp
@@ -2,12 +2,12 @@
 # define SERVER_HPP
 
 #include <poll.h>
-#include <iostream>
 #include <map>
-#include <stdexcept>
 #include <string>
 #include <vector>
+#include <iostream>
 #include <cstring>
+#include <stdexcept>
 #include "./ServerSocket.hpp"
 #include "./Config.hpp"
 #include "./Info.hpp"

--- a/hnoguchi/ft_irc/server/ServerSocket.cpp
+++ b/hnoguchi/ft_irc/server/ServerSocket.cpp
@@ -12,7 +12,8 @@ ServerSocket::ServerSocket(unsigned short port) :
 		if (fcntl(this->fd_, F_SETFL, O_NONBLOCK) < 0) {
 			throw std::runtime_error("fcntl");
 		}
-		memset(&this->address_, 0, sizeof(this->address_));
+		// memset(&this->address_, 0, sizeof(this->address_));
+		// this->address_ = {0};
 		this->address_.sin_family = AF_INET;
 		this->address_.sin_addr.s_addr = INADDR_ANY;
 		// this->address_.sin_addr.s_addr = inet_addr("224.10.10.2");

--- a/hnoguchi/ft_irc/server/ServerSocket.hpp
+++ b/hnoguchi/ft_irc/server/ServerSocket.hpp
@@ -5,8 +5,9 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
-#include <stdexcept>
+#include <string>
 #include <iostream>
+#include <stdexcept>
 
 class ServerSocket {
  private:

--- a/hnoguchi/ft_irc/server/split.cpp
+++ b/hnoguchi/ft_irc/server/split.cpp
@@ -1,6 +1,6 @@
-#include <iostream>
 #include <vector>
 #include <string>
+#include <stdexcept>
 #include "./Server.hpp"
 #include "../user/User.hpp"
 #include "../reply/Reply.hpp"
@@ -30,6 +30,7 @@ std::vector<std::string>	Server::split(const std::string& message, User* user) {
 }
 
 #ifdef UTEST_SPLIT
+#include <iostream>
 #include "../color.hpp"
 
 void	printMsg(const std::string& color, const std::string& msg) {

--- a/hnoguchi/ft_irc/user/User.cpp
+++ b/hnoguchi/ft_irc/user/User.cpp
@@ -170,6 +170,7 @@ void	User::resetData() {
 }
 
 // DEBUG
+#include <stdexcept>
 void	User::debugPrintUser() const {
 	std::cout << MAGENTA << "[USER INFO] --------------------" << END << std::endl;
 	std::cout << "[index]        : [" << this->index_ << "]" << std::endl;

--- a/hnoguchi/ft_irc/user/User.hpp
+++ b/hnoguchi/ft_irc/user/User.hpp
@@ -2,8 +2,8 @@
 # define USER_HPP
 
 #include <poll.h>
-#include <iostream>
 #include <string>
+#include <iostream>
 #include "../color.hpp"
 
 enum kUserMode {


### PR DESCRIPTION
Linux上でもコンパイル可能なよう、必要なincludeステートメントを追加。
\<unistd.h\>のmemset()を、\<cstring\>のstd::memset()へ変更。
デバッグ用関数のみに使われているものを除き、ヘッダーファイルがある場合にはヘッダーファイルへincludeステートメントを移動。\<string\>や\<stdexcept\>をそれぞれへ追加。